### PR TITLE
Feature/support raw messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+﻿# Prevent different SC's conflicting with each other (Git vs Snowtrack)
+# Do not remove this line
+.snow
+
+_renom/
+
+# Visual Studio user settings files that should be ignored.
+.vs/
+.vscode/
+*.vcxproj
+
+# Visual Studio user settings files that should be ignored.
+# And Unreal Engine directories
+Saved/
+Build/
+Binaries/
+Intermediate/
+DerivedDataCache/
+FileOpenOrder/
+Developers/
+
+*.pdb
+*-Debug.*
+*.tmp
+*.VC.db
+*.opensdf
+*.opendb
+*.sdf
+*.sln
+*.suo
+*.swp
+
+*.xcodeproj
+*.xcworkspace
+
+# Allow any files from /RawContent dir.
+# Any file in /RawContent dir will be managed by git lfs.
+!/RawContent/**/*
+
+# OS/platform generated files.
+
+# Windows
+ehthumbs.db
+Thumbs.db
+
+# Mac OS X
+.DS_Store
+.DS_Store?
+.AppleDouble
+.LSOverride
+._*
+.p4ignore.txt
+Builds

--- a/MqttUtilities/Source/MqttUtilities/Private/Linux/MqttClientImpl.cpp
+++ b/MqttUtilities/Source/MqttUtilities/Private/Linux/MqttClientImpl.cpp
@@ -3,7 +3,7 @@
 #include "MqttClientImpl.h"
 #include "MqttRunnable.h"
 
-MqttClientImpl::MqttClientImpl(const char * id) : mosqpp::mosquittopp(id)
+MqttClientImpl::MqttClientImpl(const char* id) : mosqpp::mosquittopp(id)
 {
 }
 
@@ -42,7 +42,7 @@ void MqttClientImpl::on_publish(int mid)
 	Task->OnPublished(mid);
 }
 
-void MqttClientImpl::on_message(const mosquitto_message * src)
+void MqttClientImpl::on_message(const mosquitto_message* src)
 {
 	UE_LOG(LogTemp, Warning, TEXT("MQTT => Impl: Message received"));
 
@@ -65,10 +65,20 @@ void MqttClientImpl::on_message(const mosquitto_message * src)
 
 	free(buffer);
 
+	// Create a buffer to hold the payload without converting to FString
+	TArray<uint8> Buffer;
+	// Allocate memory for the buffer to hold the payload
+	Buffer.SetNumZeroed(PayloadLength);
+	if (PayloadLength > 0) {
+		// Copy the payload to the buffer
+		FMemory::Memcpy(Buffer.GetData(), src->payload, PayloadLength);
+	}
+	msg.MessageBuffer = Buffer;
+
 	Task->OnMessage(msg);
 }
 
-void MqttClientImpl::on_subscribe(int mid, int qos_count, const int * granted_qos)
+void MqttClientImpl::on_subscribe(int mid, int qos_count, const int* granted_qos)
 {
 	UE_LOG(LogTemp, Warning, TEXT("MQTT => Impl: Subscribed"));
 

--- a/MqttUtilities/Source/MqttUtilities/Private/Mac/MqttClientImpl.cpp
+++ b/MqttUtilities/Source/MqttUtilities/Private/Mac/MqttClientImpl.cpp
@@ -3,7 +3,7 @@
 #include "MqttClientImpl.h"
 #include "MqttRunnable.h"
 
-MqttClientImpl::MqttClientImpl(const char * id) : mosqpp::mosquittopp(id)
+MqttClientImpl::MqttClientImpl(const char* id) : mosqpp::mosquittopp(id)
 {
 }
 
@@ -31,7 +31,7 @@ void MqttClientImpl::on_disconnect(int rc)
 	}
 
 	UE_LOG(LogTemp, Warning, TEXT("MQTT => Impl: Disconnected"));
-	
+
 	Task->OnDisconnect();
 }
 
@@ -42,7 +42,7 @@ void MqttClientImpl::on_publish(int mid)
 	Task->OnPublished(mid);
 }
 
-void MqttClientImpl::on_message(const mosquitto_message * src)
+void MqttClientImpl::on_message(const mosquitto_message* src)
 {
 	UE_LOG(LogTemp, Warning, TEXT("MQTT => Impl: Message received"));
 
@@ -56,7 +56,7 @@ void MqttClientImpl::on_message(const mosquitto_message * src)
 	void* buffer = malloc(PayloadLength + 1);
 	((char*)buffer)[PayloadLength] = 0;
 
-	if (buffer != NULL) 
+	if (buffer != NULL)
 	{
 		memcpy(buffer, src->payload, PayloadLength);
 	}
@@ -65,10 +65,20 @@ void MqttClientImpl::on_message(const mosquitto_message * src)
 
 	free(buffer);
 
+	// Create a buffer to hold the payload without converting to FString
+	TArray<uint8> Buffer;
+	// Allocate memory for the buffer to hold the payload
+	Buffer.SetNumZeroed(PayloadLength);
+	if (PayloadLength > 0) {
+		// Copy the payload to the buffer
+		FMemory::Memcpy(Buffer.GetData(), src->payload, PayloadLength);
+	}
+	msg.MessageBuffer = Buffer;
+
 	Task->OnMessage(msg);
 }
 
-void MqttClientImpl::on_subscribe(int mid, int qos_count, const int * granted_qos)
+void MqttClientImpl::on_subscribe(int mid, int qos_count, const int* granted_qos)
 {
 	UE_LOG(LogTemp, Warning, TEXT("MQTT => Impl: Subscribed"));
 

--- a/MqttUtilities/Source/MqttUtilities/Private/Windows/MqttClientImpl.cpp
+++ b/MqttUtilities/Source/MqttUtilities/Private/Windows/MqttClientImpl.cpp
@@ -3,7 +3,7 @@
 #include "MqttClientImpl.h"
 #include "MqttRunnable.h"
 
-MqttClientImpl::MqttClientImpl(const char * id) : mosqpp::mosquittopp(id)
+MqttClientImpl::MqttClientImpl(const char* id) : mosqpp::mosquittopp(id)
 {
 }
 
@@ -31,7 +31,7 @@ void MqttClientImpl::on_disconnect(int rc)
 	}
 
 	UE_LOG(LogTemp, Warning, TEXT("MQTT => Impl: Disconnected"));
-	
+
 	Task->OnDisconnect();
 }
 
@@ -42,7 +42,7 @@ void MqttClientImpl::on_publish(int mid)
 	Task->OnPublished(mid);
 }
 
-void MqttClientImpl::on_message(const mosquitto_message * src)
+void MqttClientImpl::on_message(const mosquitto_message* src)
 {
 	UE_LOG(LogTemp, Warning, TEXT("MQTT => Impl: Message received"));
 
@@ -56,7 +56,7 @@ void MqttClientImpl::on_message(const mosquitto_message * src)
 	void* buffer = malloc(PayloadLength + 1);
 	((char*)buffer)[PayloadLength] = 0;
 
-	if (buffer != NULL) 
+	if (buffer != NULL)
 	{
 		memcpy(buffer, src->payload, PayloadLength);
 	}
@@ -65,10 +65,20 @@ void MqttClientImpl::on_message(const mosquitto_message * src)
 
 	free(buffer);
 
+	// Create a buffer to hold the payload without converting to FString
+	TArray<uint8> Buffer;
+	// Allocate memory for the buffer to hold the payload
+	Buffer.SetNumZeroed(PayloadLength);
+	if (PayloadLength > 0) {
+		// Copy the payload to the buffer
+		FMemory::Memcpy(Buffer.GetData(), src->payload, PayloadLength);
+	}
+	msg.MessageBuffer = Buffer;
+
 	Task->OnMessage(msg);
 }
 
-void MqttClientImpl::on_subscribe(int mid, int qos_count, const int * granted_qos)
+void MqttClientImpl::on_subscribe(int mid, int qos_count, const int* granted_qos)
 {
 	UE_LOG(LogTemp, Warning, TEXT("MQTT => Impl: Subscribed"));
 

--- a/MqttUtilities/Source/MqttUtilities/Public/Entities/MqttMessage.h
+++ b/MqttUtilities/Source/MqttUtilities/Public/Entities/MqttMessage.h
@@ -9,19 +9,23 @@ struct MQTTUTILITIES_API FMqttMessage
 {
 	GENERATED_BODY()
 
-    /** Message content. */
+	/** Message content. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MQTT")
 	FString Message;
 
-    /** Message topic. */
+	/** Message content buffer. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MQTT")
+	TArray<uint8> MessageBuffer;
+
+	/** Message topic. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MQTT")
 	FString Topic;
 
-    /** Retain flag. */
+	/** Retain flag. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MQTT")
 	bool Retain;
 
-    /** Quality of signal. */
+	/** Quality of signal. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MQTT")
 	int Qos;
 };


### PR DESCRIPTION
For a project we are sending msgpack format instead of plain JSON.
Currently the plugin only returns the payload as FString which can't be decoded from msgpack.
This PR adds an additional field MessageBuffer to FMqttMessage to support handling msgpack format (`TArray<uint8>` as well).

We've used Epic's MQTT plugin (in Beta) as it did return the payload as `TArray<uint8>`, but it was very unstable and had issues connecting to remote brokers. 

## Changes
- Addition of `MessageBuffer` to struct `FMqttMessage` for Windows, Mac, Linux
- Addition of .gitignore to prevent unnecessary files

## Notes
- Tested with UE 5+
- Tested with Windows x64
- Tested on M1 Mac but the plugin crashes (There are existing tickets in the Issues related to this)
- Linux untested
- IOS & Android unchanged and untested - Would be great if someone knows what to update in there
