### PR TITLE
Fix UE5.3 Linux Compile

### DIFF
--- a/MqttUtilities/Source/MqttUtilities/Private/Linux/Utils/StringUtils.cpp
+++ b/MqttUtilities/Source/MqttUtilities/Private/Linux/Utils/StringUtils.cpp
@@ -4,7 +4,8 @@
 
 char* StringUtils::CopyString(FString str)
 {
-	const char* originalStr = TCHAR_TO_ANSI(*str);
+	auto StringCaster = StringCast<ANSICHAR>(static_cast<const TCHAR*>(*str));
+	const char* originalStr = StringCaster.Get();
 	
 	char *copyStr;
 	size_t str_len;


### PR DESCRIPTION
Fix for pointer error
Took the implementation from the Windows StringUtils.cpp which seems to work fine