### PR TITLE
Fix string caster deprecation warning for Linux and Mac

### DIFF
--- a/MqttUtilities/Source/MqttUtilities/Private/Linux/Utils/StringUtils.cpp
+++ b/MqttUtilities/Source/MqttUtilities/Private/Linux/Utils/StringUtils.cpp
@@ -4,7 +4,8 @@
 
 char* StringUtils::CopyString(FString str)
 {
-	const char* originalStr = TCHAR_TO_ANSI(*str);
+	auto StringCaster = StringCast<ANSICHAR>(static_cast<const TCHAR*>(*str));
+	const char* originalStr = StringCaster.Get();
 	
 	char *copyStr;
 	size_t str_len;

--- a/MqttUtilities/Source/MqttUtilities/Private/Mac/Utils/StringUtils.cpp
+++ b/MqttUtilities/Source/MqttUtilities/Private/Mac/Utils/StringUtils.cpp
@@ -4,7 +4,8 @@
 
 char* StringUtils::CopyString(FString str)
 {
-	const char* originalStr = TCHAR_TO_ANSI(*str);
+	auto StringCaster = StringCast<ANSICHAR>(static_cast<const TCHAR*>(*str));
+	const char* originalStr = StringCaster.Get();
 	
 	char *copyStr;
 	size_t str_len;


### PR DESCRIPTION
Unreal 5.X depreation warning when compiling on Linux:
```
Plugins\MqttUtilities\Source\MqttUtilities\Private\Linux\Utils\StringUtils.cpp(7,28): error: temporary whose address is used as value of local variable 'originalStr' will be destroyed at the end of the full-expression [-Werror,-Wdangling]
const char* originalStr = TCHAR_TO_ANSI(*str);
```

Copying the solution that was already implemented for Windows.
