### PR TITLE
Fixed: 128 characters with Windows

### DIFF
--- a/MqttUtilities/Source/MqttUtilities/Private/Windows/Utils/StringUtils.cpp
+++ b/MqttUtilities/Source/MqttUtilities/Private/Windows/Utils/StringUtils.cpp
@@ -4,7 +4,8 @@
 
 char* StringUtils::CopyString(FString str)
 {
-	const char* originalStr = TCHAR_TO_ANSI(*str);
+	auto originalFString = StringCast<ANSICHAR>(*str);
+	const char* originalStr = originalFString.Get();
 	
 	char *copyStr;
 	size_t str_len;


### PR DESCRIPTION
Cannot send messages with more than 128 characters with Windows